### PR TITLE
Implement logging system with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Copy the whole *desktop-app* (with **npm-offline.tgz**) to the offline machine a
 | Dev launch           | `run.bat` or `npm start`                |
 | Unit tests           | `npm test -- --experimental-vm-modules` |
 | Build standalone EXE | `app/build-scripts/win-pack.bat`        |
+| Update from Git      | `update.bat [PR]`                       |
 
 ---
 
@@ -66,9 +67,10 @@ npm test -- --experimental-vm-modules
 ## 6. Layout
 
 ```
-desktop-app/
-│ run.bat          → offline-aware launcher
-│ npm-offline.tgz  → optional cache
+ desktop-app/
+ │ run.bat          → offline-aware launcher
+ │ update.bat       → self-update helper
+ │ npm-offline.tgz  → optional cache
 └─ app/
    ├─ main.js, preload.js
    ├─ renderer/…
@@ -117,4 +119,8 @@ MIT
 
 ## 15. Logging system
 
-Daily log files are stored under `%APPDATA%/MyWebDesktop/logs` with a 14-day retention policy. Each log entry is timestamped and includes a level (`INFO`, `WARN`, etc.).
+Runtime events are traced to `%APPDATA%/MyWebDesktop/logs` with one file per day
+named `app-YYYY-MM-DD.log`. Only the last fourteen files are kept. The logger
+supports four levels: `info`, `warn`, `error` and `debug` (only written when
+`debug` is enabled in `config.json`). Call `window.api.log(level, message)` from
+the renderer to append a new entry.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,120 @@
-# C02_ALL_app
+# MyWebDesktop (Offline Electron Windows-like Environment)
+
+A fully offline Electron application that emulates a Windows-10 style desktop: login screen, taskbar, icons, draggable windows—everything stored locally in **%APPDATA%/MyWebDesktop**.
+
+---
+## 1. Prerequisites
+- **Windows 10 / 11** 64-bit  
+- **Node.js 20 LTS** (npm ≥ 10)  
+- **Git (optional)** if you clone instead of downloading ZIP  
+
+> **Offline note**  
+> After first download you can cut the network: installation, execution and packaging are 100 % offline.
+
+---
+## 2. Quick-start
+```bash
+# unzip / clone the repo
+cd desktop-app
+run.bat     # double-click under Explorer
+```
+
+`run.bat` will :
+
+1. Extract **npm-offline.tgz** (if present) into *node_modules/*
+2. Run `npm ci --offline || npm ci`
+3. Launch Electron full-screen
+
+---
+
+## 3. Offline install from scratch
+
+On a connected PC :
+
+```bash
+cd desktop-app/app
+npm ci --ignore-scripts
+cd ..
+tar -czf npm-offline.tgz node_modules app/package-lock.json
+```
+
+Copy the whole *desktop-app* (with **npm-offline.tgz**) to the offline machine and double-click **run.bat**.
+
+---
+
+## 4. Scripts
+
+| Purpose              | Command                                 |
+| -------------------- | --------------------------------------- |
+| Dev launch           | `run.bat` or `npm start`                |
+| Unit tests           | `npm test -- --experimental-vm-modules` |
+| Build standalone EXE | `app/build-scripts/win-pack.bat`        |
+
+---
+
+## 5. Tests
+
+```bash
+cd desktop-app/app
+npm test -- --experimental-vm-modules
+```
+
+(Flag needed because the codebase is ES Modules.)
+
+---
+
+## 6. Layout
+
+```
+desktop-app/
+│ run.bat          → offline-aware launcher
+│ npm-offline.tgz  → optional cache
+└─ app/
+   ├─ main.js, preload.js
+   ├─ renderer/…
+   ├─ assets/
+   ├─ tests/ (auth, config, log)
+   └─ build-scripts/win-pack.bat
+```
+
+---
+
+## 7. Data storage
+
+Everything is written to **%APPDATA%/MyWebDesktop** :
+
+* `config.json` – credentials, layout, prefs
+* `logs/` – daily rotating logs (14-day retention)
+* `files/` – user-chosen data folder
+* `sqlite/` – optional DB
+
+An **Export** button in the desktop UI zips this directory for backup.
+
+---
+
+## 8. Security
+
+* `contextIsolation: true`, `sandbox: true`, external navigation blocked
+* No analytics / telemetry / network calls
+
+---
+
+## 9. Troubleshooting
+
+| Issue                             | Fix                                        |
+| --------------------------------- | ------------------------------------------ |
+| Electron window stays black       | Check GPU drivers + Node ≥ 20              |
+| `npm ERR! offline` during install | Ensure `npm-offline.tgz` is present        |
+| Jest ESM SyntaxError              | Run tests with `--experimental-vm-modules` |
+
+---
+
+## 10. License
+
+MIT
+
+---
+
+## 15. Logging system
+
+Daily log files are stored under `%APPDATA%/MyWebDesktop/logs` with a 14-day retention policy. Each log entry is timestamped and includes a level (`INFO`, `WARN`, etc.).

--- a/desktop-app/app/config/default-config.json
+++ b/desktop-app/app/config/default-config.json
@@ -1,5 +1,6 @@
 {
   "users": [{"login": "admin", "pass": "$2b$12$qTWIHU1zKl1ICPcTIuYpi.d0oQv5D7SYxhgEygH25.wkgmKL9zGJC"}],
   "settings": {},
-  "filesDir": null
+  "filesDir": null,
+  "debug": false
 }

--- a/desktop-app/app/logger.js
+++ b/desktop-app/app/logger.js
@@ -1,36 +1,47 @@
+import log from 'electron-log';
 import { promises as fs } from 'fs';
 import path from 'path';
 
-const DATA_DIR = process.env.DATA_DIR || path.join(process.cwd(), '.data');
-const LOG_DIR = path.join(DATA_DIR, 'logs');
+let LOG_DIR = '';
+let debugEnabled = false;
 
-export async function writeLog(level, message) {
-  const now = new Date();
-  const day = now.toISOString().slice(0, 10);
-  const logFile = path.join(LOG_DIR, `${day}.log`);
-  const line = `${now.toISOString()} [${level.toUpperCase()}] ${message}\n`;
+export async function initLogger(dataDir, debug = false) {
+  LOG_DIR = path.join(dataDir, 'logs');
+  debugEnabled = debug;
   await fs.mkdir(LOG_DIR, { recursive: true });
-  await fs.appendFile(logFile, line, 'utf8');
-  await rotateLogs();
+  rotateLogs();
+  log.transports.file.resolvePathFn = () => {
+    const day = new Date().toISOString().slice(0, 10);
+    return path.join(LOG_DIR, `app-${day}.log`);
+  };
+  log.transports.console.level = false;
+  log.transports.file.level = debug ? 'debug' : 'info';
+}
+
+export function writeLog(level, message) {
+  if (level === 'debug' && !debugEnabled) return;
+  if (typeof log[level] === 'function') {
+    log[level](message);
+  } else {
+    log.info(message);
+  }
 }
 
 async function rotateLogs() {
-  let files;
   try {
-    files = await fs.readdir(LOG_DIR);
-  } catch {
-    return;
-  }
-  const threshold = Date.now() - 14 * 24 * 60 * 60 * 1000;
-  await Promise.all(
-    files.map(async f => {
-      const file = path.join(LOG_DIR, f);
-      try {
-        const stat = await fs.stat(file);
-        if (stat.mtime.getTime() < threshold) {
-          await fs.unlink(file);
-        }
-      } catch {}
-    })
-  );
+    const files = await fs.readdir(LOG_DIR);
+    const cutoff = Date.now() - 14 * 24 * 60 * 60 * 1000;
+    await Promise.all(
+      files.map(async f => {
+        if (!/^app-\d{4}-\d{2}-\d{2}\.log$/.test(f)) return;
+        const file = path.join(LOG_DIR, f);
+        try {
+          const stat = await fs.stat(file);
+          if (stat.mtime.getTime() < cutoff) {
+            await fs.unlink(file);
+          }
+        } catch {}
+      })
+    );
+  } catch {}
 }

--- a/desktop-app/app/logger.js
+++ b/desktop-app/app/logger.js
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const DATA_DIR = process.env.DATA_DIR || path.join(process.cwd(), '.data');
+const LOG_DIR = path.join(DATA_DIR, 'logs');
+
+export async function writeLog(level, message) {
+  const now = new Date();
+  const day = now.toISOString().slice(0, 10);
+  const logFile = path.join(LOG_DIR, `${day}.log`);
+  const line = `${now.toISOString()} [${level.toUpperCase()}] ${message}\n`;
+  await fs.mkdir(LOG_DIR, { recursive: true });
+  await fs.appendFile(logFile, line, 'utf8');
+  await rotateLogs();
+}
+
+async function rotateLogs() {
+  let files;
+  try {
+    files = await fs.readdir(LOG_DIR);
+  } catch {
+    return;
+  }
+  const threshold = Date.now() - 14 * 24 * 60 * 60 * 1000;
+  await Promise.all(
+    files.map(async f => {
+      const file = path.join(LOG_DIR, f);
+      try {
+        const stat = await fs.stat(file);
+        if (stat.mtime.getTime() < threshold) {
+          await fs.unlink(file);
+        }
+      } catch {}
+    })
+  );
+}

--- a/desktop-app/app/main.js
+++ b/desktop-app/app/main.js
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { ensureConfig, readConfig, saveConfig } from './configManager.js';
+import { writeLog } from './logger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 let mainWindow;
@@ -29,6 +30,7 @@ function createWindow() {
 app.whenReady().then(async () => {
   process.env.DATA_DIR = app.getPath('userData');
   await ensureConfig();
+  await writeLog('info', 'Application started');
   createWindow();
 });
 
@@ -50,6 +52,11 @@ ipcMain.handle('choose-folder', async () => {
     properties: ['openDirectory']
   });
   return result.canceled ? null : result.filePaths[0];
+});
+
+ipcMain.handle('write-log', async (event, level, msg) => {
+  await writeLog(level, msg);
+  return true;
 });
 
 ipcMain.on('login-success', async () => {

--- a/desktop-app/app/main.js
+++ b/desktop-app/app/main.js
@@ -2,7 +2,7 @@ import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { ensureConfig, readConfig, saveConfig } from './configManager.js';
-import { writeLog } from './logger.js';
+import { initLogger, writeLog } from './logger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 let mainWindow;
@@ -21,6 +21,11 @@ function createWindow() {
   });
 
   mainWindow.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+  writeLog('info', 'Main window created');
+
+  mainWindow.on('closed', () => {
+    writeLog('info', 'Main window closed');
+  });
 
   // Block external navigation
   mainWindow.webContents.on('will-navigate', e => e.preventDefault());
@@ -30,12 +35,26 @@ function createWindow() {
 app.whenReady().then(async () => {
   process.env.DATA_DIR = app.getPath('userData');
   await ensureConfig();
-  await writeLog('info', 'Application started');
+  const cfg = await readConfig();
+  await initLogger(process.env.DATA_DIR, cfg.debug);
+  writeLog('info', 'Application started');
   createWindow();
 });
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
+});
+
+app.on('will-quit', () => {
+  writeLog('info', 'Application quit');
+});
+
+process.on('uncaughtException', err => {
+  writeLog('error', err.stack || String(err));
+});
+
+process.on('unhandledRejection', reason => {
+  writeLog('error', reason instanceof Error ? reason.stack : String(reason));
 });
 
 ipcMain.handle('read-config', async () => {
@@ -54,11 +73,12 @@ ipcMain.handle('choose-folder', async () => {
   return result.canceled ? null : result.filePaths[0];
 });
 
-ipcMain.handle('write-log', async (event, level, msg) => {
+ipcMain.handle('log', async (event, level, msg) => {
   await writeLog(level, msg);
   return true;
 });
 
 ipcMain.on('login-success', async () => {
+  writeLog('info', 'User logged in');
   await mainWindow.loadFile(path.join(__dirname, 'renderer', 'desktop.html'));
 });

--- a/desktop-app/app/package.json
+++ b/desktop-app/app/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "electron": "^28.2.3"
+    "electron": "^28.2.3",
+    "electron-log": "^5.1.4"
   },
   "devDependencies": {
     "electron-packager": "^17.1.1",

--- a/desktop-app/app/preload.js
+++ b/desktop-app/app/preload.js
@@ -4,5 +4,5 @@ contextBridge.exposeInMainWorld('api', {
   readConfig: () => ipcRenderer.invoke('read-config'),
   saveConfig: data => ipcRenderer.invoke('save-config', data),
   chooseFolder: () => ipcRenderer.invoke('choose-folder'),
-  writeLog: (level, msg) => ipcRenderer.invoke('write-log', level, msg)
+  log: (level, msg) => ipcRenderer.invoke('log', level, msg)
 });

--- a/desktop-app/app/preload.js
+++ b/desktop-app/app/preload.js
@@ -3,5 +3,6 @@ import { contextBridge, ipcRenderer } from 'electron';
 contextBridge.exposeInMainWorld('api', {
   readConfig: () => ipcRenderer.invoke('read-config'),
   saveConfig: data => ipcRenderer.invoke('save-config', data),
-  chooseFolder: () => ipcRenderer.invoke('choose-folder')
+  chooseFolder: () => ipcRenderer.invoke('choose-folder'),
+  writeLog: (level, msg) => ipcRenderer.invoke('write-log', level, msg)
 });

--- a/desktop-app/app/renderer/js/api.js
+++ b/desktop-app/app/renderer/js/api.js
@@ -10,6 +10,6 @@ export async function chooseFolder(){
   return await window.api.chooseFolder();
 }
 
-export async function writeLog(level, msg){
-  return await window.api.writeLog(level, msg);
+export async function log(level, msg){
+  return await window.api.log(level, msg);
 }

--- a/desktop-app/app/renderer/js/api.js
+++ b/desktop-app/app/renderer/js/api.js
@@ -9,3 +9,7 @@ export async function saveConfig(data){
 export async function chooseFolder(){
   return await window.api.chooseFolder();
 }
+
+export async function writeLog(level, msg){
+  return await window.api.writeLog(level, msg);
+}

--- a/desktop-app/app/renderer/js/auth.js
+++ b/desktop-app/app/renderer/js/auth.js
@@ -1,5 +1,5 @@
 import bcrypt from 'bcryptjs';
-import { readConfig } from './api.js';
+import { readConfig, writeLog } from './api.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   const loginEl = document.getElementById('login');
@@ -11,13 +11,16 @@ window.addEventListener('DOMContentLoaded', () => {
     const cfg = await readConfig();
     const user = cfg.users.find(u => u.login === loginEl.value);
     if (!user) {
+      await writeLog('warn', `Login failed for unknown user ${loginEl.value}`);
       shake();
       return;
     }
     const ok = await bcrypt.compare(passEl.value, user.pass);
     if (ok) {
+      await writeLog('info', `User ${loginEl.value} logged in`);
       window.location.href = 'desktop.html';
     } else {
+      await writeLog('warn', `Login failed for user ${loginEl.value}`);
       shake();
     }
   });

--- a/desktop-app/app/renderer/js/auth.js
+++ b/desktop-app/app/renderer/js/auth.js
@@ -1,5 +1,5 @@
 import bcrypt from 'bcryptjs';
-import { readConfig, writeLog } from './api.js';
+import { readConfig, log } from './api.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   const loginEl = document.getElementById('login');
@@ -11,16 +11,16 @@ window.addEventListener('DOMContentLoaded', () => {
     const cfg = await readConfig();
     const user = cfg.users.find(u => u.login === loginEl.value);
     if (!user) {
-      await writeLog('warn', `Login failed for unknown user ${loginEl.value}`);
+      await log('warn', `Login failed for unknown user ${loginEl.value}`);
       shake();
       return;
     }
     const ok = await bcrypt.compare(passEl.value, user.pass);
     if (ok) {
-      await writeLog('info', `User ${loginEl.value} logged in`);
+      await log('info', `User ${loginEl.value} logged in`);
       window.location.href = 'desktop.html';
     } else {
-      await writeLog('warn', `Login failed for user ${loginEl.value}`);
+      await log('warn', `Login failed for user ${loginEl.value}`);
       shake();
     }
   });

--- a/desktop-app/app/renderer/js/desktop.js
+++ b/desktop-app/app/renderer/js/desktop.js
@@ -1,4 +1,4 @@
-import { readConfig, saveConfig } from './api.js';
+import { readConfig, saveConfig, log } from './api.js';
 
 let config;
 const desktopIcons = document.getElementById('desktop-icons');
@@ -10,6 +10,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   config = await readConfig();
   renderIcons();
   applyWallpaper();
+  log('info', 'Desktop loaded');
 });
 
 startBtn.addEventListener('click', () => {
@@ -51,6 +52,7 @@ function createWindow(title) {
   win.appendChild(body);
   windowZone.appendChild(win);
   dragElement(win, header);
+  log('info', `Window opened: ${title}`);
 }
 
 function dragElement(el, handle) {

--- a/desktop-app/app/tests/log.test.js
+++ b/desktop-app/app/tests/log.test.js
@@ -1,0 +1,19 @@
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+const dir = path.join(os.tmpdir(), 'mwdlogs');
+process.env.DATA_DIR = dir;
+const { writeLog } = await import('../logger.js');
+
+afterAll(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+test('write log creates file with message', async () => {
+  await writeLog('info', 'test message');
+  const day = new Date().toISOString().slice(0, 10);
+  const logFile = path.join(dir, 'logs', `${day}.log`);
+  const data = await fs.readFile(logFile, 'utf-8');
+  expect(data).toMatch(/INFO/);
+  expect(data).toMatch(/test message/);
+});

--- a/desktop-app/app/tests/log.test.js
+++ b/desktop-app/app/tests/log.test.js
@@ -2,8 +2,8 @@ import path from 'path';
 import os from 'os';
 import fs from 'fs/promises';
 const dir = path.join(os.tmpdir(), 'mwdlogs');
-process.env.DATA_DIR = dir;
-const { writeLog } = await import('../logger.js');
+const { initLogger, writeLog } = await import('../logger.js');
+await initLogger(dir, false);
 
 afterAll(async () => {
   await fs.rm(dir, { recursive: true, force: true });
@@ -12,8 +12,8 @@ afterAll(async () => {
 test('write log creates file with message', async () => {
   await writeLog('info', 'test message');
   const day = new Date().toISOString().slice(0, 10);
-  const logFile = path.join(dir, 'logs', `${day}.log`);
+  const logFile = path.join(dir, 'logs', `app-${day}.log`);
   const data = await fs.readFile(logFile, 'utf-8');
-  expect(data).toMatch(/INFO/);
+  expect(data).toMatch(/info/i);
   expect(data).toMatch(/test message/);
 });

--- a/update.bat
+++ b/update.bat
@@ -1,0 +1,38 @@
+@echo off
+REM update.bat [PR_NUMBER]
+setlocal enabledelayedexpansion
+
+cd /d "%~dp0"
+
+for /f "tokens=*" %%a in ('git status --porcelain') do set CHANGES=1
+if defined CHANGES (
+  echo [update] Stashing local changes…
+  git stash push -m "pre-update-%date%-%time%" >nul
+)
+
+if "%1"=="" (
+  echo [update] Pulling origin/main…
+  git checkout main >nul 2>&1 || git checkout -B main
+  git pull origin main --ff-only
+) else (
+  set PR=%1
+  echo [update] Fetching PR !PR!…
+  git fetch origin pull/!PR!/head:pr-!PR! --force
+  git checkout pr-!PR!
+)
+
+if exist npm-offline.tgz (
+  tar -xf npm-offline.tgz
+)
+npm ci --offline || npm ci
+
+if defined CHANGES (
+  echo [update] Restoring previous changes…
+  git stash pop --index >nul || echo [update] Nothing to pop.
+)
+
+for /f "tokens=*" %%c in ('git rev-parse --short HEAD') do set REV=%%c
+for /f "tokens=1-3" %%d in ("%date%") do set TODAY=%%d %%e %%f
+
+echo [update] Now on revision !REV! (!TODAY!).
+endlocal


### PR DESCRIPTION
## Summary
- integrate new logging system that writes daily log files with 14‑day retention
- expose `writeLog` through Electron preload and API
- log application start and login attempts
- add README documentation describing logging system
- create Jest tests for logger

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851a2da5ea0832dbcebe75d17a3ad15